### PR TITLE
xcontext: add KeepAlive function

### DIFF
--- a/xcontext/xcontext.go
+++ b/xcontext/xcontext.go
@@ -13,6 +13,7 @@ package xcontext
 
 import (
 	"context"
+	"sync"
 	"time"
 )
 
@@ -26,3 +27,103 @@ func (v noDeadlineContext) Deadline() (time.Time, bool)       { return time.Time
 func (v noDeadlineContext) Done() <-chan struct{}             { return nil }
 func (v noDeadlineContext) Err() error                        { return nil }
 func (v noDeadlineContext) Value(key interface{}) interface{} { return v.parent.Value(key) }
+
+// KeepAlive returns a context that keeps all the values of its parent context
+// and ensures that it is not marked Done for at least d time.
+func KeepAlive(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	// Compute deadline as close to start of function as possible.
+	minDeadline := time.Now().Add(d)
+
+	parentDone := parent.Done()
+	if parentDone == nil {
+		// Optimization: if the parent context can never be Done, then the only Done
+		// signal can be from the returned cancel function.
+		return context.WithCancel(parent)
+	}
+	select {
+	case <-parentDone:
+		// Optimization: if the parent context has already been canceled, then the
+		// given duration is the deadline.
+		return context.WithDeadline(IgnoreDeadline(parent), minDeadline)
+	default:
+	}
+
+	// Otherwise, keep Done open until d has elapsed or the parent's Done channel
+	// is closed, whichever comes last. Calling the returned cancel function
+	// has priority over either condition.
+	timer := time.NewTimer(time.Until(minDeadline))
+	k := &keepAlive{
+		parent: parent,
+		done:   make(chan struct{}),
+	}
+	if k.deadline, k.hasDeadline = parent.Deadline(); k.hasDeadline {
+		if k.deadline.Before(minDeadline) {
+			k.deadline = minDeadline
+		}
+	}
+	var cancelOnce sync.Once
+	canceled := make(chan struct{})
+	cancelerDone := make(chan struct{})
+	go func() {
+		defer close(cancelerDone)
+		defer timer.Stop()
+
+		select {
+		case <-timer.C:
+			// Waited the minimum time. Now propagate the parent Done.
+			select {
+			case <-parentDone:
+				k.stop(parent.Err())
+			case <-canceled:
+				k.stop(context.Canceled)
+			}
+		case <-canceled:
+			// Canceled before the minimum time elapsed.
+			k.stop(context.Canceled)
+		}
+	}()
+	return k, func() {
+		cancelOnce.Do(func() {
+			close(canceled)
+			<-cancelerDone
+		})
+	}
+}
+
+type keepAlive struct {
+	parent      context.Context
+	deadline    time.Time
+	hasDeadline bool
+	done        chan struct{}
+
+	mu  sync.RWMutex
+	err error
+}
+
+func (k *keepAlive) Deadline() (time.Time, bool) {
+	return k.deadline, k.hasDeadline
+}
+
+func (k *keepAlive) Done() <-chan struct{} {
+	return k.done
+}
+
+func (k *keepAlive) Err() error {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	return k.err
+}
+
+func (k *keepAlive) stop(e error) {
+	if e == nil {
+		panic("keepAlive.stop called with nil error")
+	}
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.err = e
+	close(k.done)
+}
+
+func (k *keepAlive) Value(key interface{}) interface{} {
+	return k.parent.Value(key)
+}

--- a/xcontext/xcontext_test.go
+++ b/xcontext/xcontext_test.go
@@ -1,0 +1,128 @@
+// Copyright 2020 YourBase Inc.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package xcontext
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestKeepAlive(t *testing.T) {
+	const keepAlive = 10 * time.Millisecond
+
+	t.Run("ParentBackground", func(t *testing.T) {
+		k, cancelK := KeepAlive(context.Background(), keepAlive)
+		defer cancelK()
+		time.Sleep(keepAlive)
+		select {
+		case <-k.Done():
+			t.Errorf("KeepAlive(ctx, %v).Done() closed before cancel", keepAlive)
+		default:
+		}
+
+		cancelK()
+		<-k.Done()
+		if got := k.Err(); !errors.Is(got, context.Canceled) {
+			t.Errorf("KeepAlive(ctx, %v).Err() = %v; want %v", keepAlive, got, context.Canceled)
+		}
+	})
+
+	t.Run("CancelParentBeforeWait", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		start := time.Now()
+		k, cancelK := KeepAlive(ctx, keepAlive)
+		defer cancelK()
+
+		<-k.Done()
+		if got := time.Since(start); got < keepAlive {
+			t.Errorf("KeepAlive(ctx, %v).Done() closed after %v; want at least %v",
+				keepAlive, got, keepAlive)
+		}
+		if got := k.Err(); !errors.Is(got, context.DeadlineExceeded) {
+			t.Errorf("KeepAlive(ctx, %v).Err() = %v; want %v", keepAlive, got, context.DeadlineExceeded)
+		}
+	})
+
+	t.Run("CancelParentDuringWait", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		start := time.Now()
+		k, cancelK := KeepAlive(ctx, keepAlive)
+		defer cancelK()
+
+		cancel()
+		<-k.Done()
+		if got := time.Since(start); got < keepAlive {
+			t.Errorf("KeepAlive(ctx, %v).Done() closed after %v; want at least %v",
+				keepAlive, got, keepAlive)
+		}
+		if got := k.Err(); !errors.Is(got, context.Canceled) {
+			t.Errorf("KeepAlive(ctx, %v).Err() = %v; want %v", keepAlive, got, context.Canceled)
+		}
+	})
+
+	t.Run("CancelChildDuringWait", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		k, cancelK := KeepAlive(ctx, keepAlive)
+		defer cancelK()
+
+		cancelK()
+		<-k.Done()
+		if got := k.Err(); !errors.Is(got, context.Canceled) {
+			t.Errorf("KeepAlive(ctx, %v).Err() = %v; want %v", keepAlive, got, context.Canceled)
+		}
+	})
+
+	t.Run("CancelChildAfterWait", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		k, cancelK := KeepAlive(ctx, keepAlive)
+		defer cancelK()
+
+		time.Sleep(keepAlive)
+		cancelK()
+		<-k.Done()
+		if got := k.Err(); !errors.Is(got, context.Canceled) {
+			t.Errorf("KeepAlive(ctx, %v).Err() = %v; want %v", keepAlive, got, context.Canceled)
+		}
+	})
+
+	t.Run("ExtendDeadline", func(t *testing.T) {
+		testStart := time.Now()
+		ctx, cancel := context.WithDeadline(context.Background(), testStart.Add(keepAlive-1*time.Millisecond))
+		defer cancel()
+
+		start := time.Now()
+		k, cancelK := KeepAlive(ctx, keepAlive)
+		defer cancelK()
+
+		want := start.Add(keepAlive)
+		if got, ok := k.Deadline(); !ok || got.Before(want) {
+			t.Errorf("KeepAlive(ctx, %v).Deadline() = %v, %t; want >=%v, true", keepAlive, got, ok, want)
+		}
+	})
+
+	t.Run("LongDeadline", func(t *testing.T) {
+		// This test can fail if executed too slowly, but we intentionally pick a
+		// really long timeout we hope to never see.
+		want := time.Now().Add(9000 * time.Hour)
+		ctx, cancel := context.WithDeadline(context.Background(), want)
+		defer cancel()
+
+		k, cancelK := KeepAlive(ctx, keepAlive)
+		defer cancelK()
+
+		if got, ok := k.Deadline(); !ok || !got.Equal(want) {
+			t.Errorf("KeepAlive(ctx, %v).Deadline() = %v, %t; want %v, true", keepAlive, got, ok, want)
+		}
+	})
+}


### PR DESCRIPTION
Useful for cleanup tasks that can possibly last past the end of the parent `Context`'s deadline, but you don't want them to run indefinitely.